### PR TITLE
Gradle use build cache

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "fastlane"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.application'
 
+
 android {
     compileSdkVersion 28
     defaultConfig {

--- a/app/src/main/java/com/ndifreke/developers/activities/DetailActivity.java
+++ b/app/src/main/java/com/ndifreke/developers/activities/DetailActivity.java
@@ -13,7 +13,6 @@ import android.widget.ImageView;
 import android.widget.TextView;
 import com.ndifreke.developers.R;
 import com.ndifreke.developers.dialog.ProfileShareDialog;
-import com.ndifreke.developers.features.githubusers.GithubCacheHelper;
 import com.ndifreke.developers.features.githubusers.GithubUser;
 import com.ndifreke.developers.features.githubusers.GithubUserObserver;
 import android.support.v7.graphics.Palette;

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,4 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-
 buildscript {
     repositories {
         google()
@@ -18,7 +17,6 @@ allprojects {
     repositories {
         google()
         jcenter()
-        
     }
 }
 

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,0 +1,2 @@
+json_key_file("") # Path to the json secret file - Follow https://docs.fastlane.tools/actions/supply/#setup to get one
+package_name("com.ndifreke.developers") # e.g. com.krausefx.app

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,38 @@
+# This file contains the fastlane.tools configuration
+# You can find the documentation at https://docs.fastlane.tools
+#
+# For a list of all available actions, check out
+#
+#     https://docs.fastlane.tools/actions
+#
+# For a list of all available plugins, check out
+#
+#     https://docs.fastlane.tools/plugins/available-plugins
+#
+
+# Uncomment the line if you want fastlane to automatically update itself
+# update_fastlane
+
+default_platform(:android)
+
+platform :android do
+  desc "Runs all the tests"
+  lane :test do
+    gradle(task: "test")
+  end
+
+  desc "Submit a new Beta Build to Crashlytics Beta"
+  lane :beta do
+    gradle(task: "clean assembleRelease")
+    crashlytics
+  
+    # sh "your_script.sh"
+    # You can also use other beta testing services here
+  end
+
+  desc "Deploy a new version to the Google Play"
+  lane :deploy do
+    gradle(task: "clean assembleRelease")
+    upload_to_play_store
+  end
+end

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,5 +11,4 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-
-
+org.gradle.caching=true


### PR DESCRIPTION
#### What this PR does 
- Enable Gradle to use the build cache

#### Task to be completed by this PR
- Make Gradle build faster

####  Screenshots

#### Before Cache Implementation
<img width="1190" alt="2" src="https://user-images.githubusercontent.com/12186332/57692984-08416a00-7640-11e9-95c2-fe4d61453f6e.png">

#### After Cache Implementation
<img width="1190" alt="1" src="https://user-images.githubusercontent.com/12186332/57692975-0081c580-7640-11e9-85d0-fdac4a7fd39c.png">




#### Relevant pivotal tracker stories
[#158787482](https://www.pivotaltracker.com/n/projects/2155295/stories/158787482)